### PR TITLE
ENG-422: FlyTSGo OTel

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -47,6 +47,20 @@ Compiles and bundles the project using esbuild. Entry point is read from `packag
 **Query Parameters:**
 - `skip_typecheck=true` — skip the typecheck step, compile only
 
+#### `POST /v3/flush-deps`
+
+Flushes cached v3 dependency trees.
+
+**Query Parameters:**
+- `lock_hash=<sha256>` — flush only the dependency cache for this `bun.lock` hash. Without this parameter, all dependency caches are flushed.
+
+#### `POST /v3/prewarm-deps`
+
+Resolves and warms the dependency cache for an uploaded `package.json` and `bun.lock`. The request uses the same multipart file format as `/v3/typecheck` and `/v3/compile`, but source files are not required.
+
+**Query Parameters:**
+- `flush=true` — first flush the dependency cache for the uploaded `bun.lock` hash, then resolve it again.
+
 #### Request Format
 
 `Content-Type: multipart/form-data`

--- a/server/server.go
+++ b/server/server.go
@@ -1190,6 +1190,16 @@ func flushDeps(w http.ResponseWriter, req *http.Request) {
 func flushAllDeps(ctx context.Context) (flushDepsResult, error) {
 	var result flushDepsResult
 
+	finishFlush, err := beginDepFlushAll(ctx)
+	if err != nil {
+		return result, fmt.Errorf("wait for dependency flush: %w", err)
+	}
+	defer finishFlush()
+
+	if err := waitForAllDepCacheUse(ctx); err != nil {
+		return result, fmt.Errorf("wait for active dependency cache readers: %w", err)
+	}
+
 	if err := waitForAllDepInstalls(ctx); err != nil {
 		return result, fmt.Errorf("wait for in-flight dependency installs: %w", err)
 	}
@@ -1249,6 +1259,10 @@ func flushDepsHash(ctx context.Context, hash string) (flushDepsResult, error) {
 		return result, fmt.Errorf("wait for dependency flush %s: %w", hash, err)
 	}
 	defer finishFlush()
+
+	if err := waitForDepCacheUse(ctx, hash); err != nil {
+		return result, fmt.Errorf("wait for active dependency cache readers %s: %w", hash, err)
+	}
 
 	if err := waitForDepInstall(ctx, hash); err != nil {
 		return result, fmt.Errorf("wait for in-flight dependency install %s: %w", hash, err)

--- a/server/server.go
+++ b/server/server.go
@@ -1244,6 +1244,12 @@ func flushAllDeps(ctx context.Context) (flushDepsResult, error) {
 func flushDepsHash(ctx context.Context, hash string) (flushDepsResult, error) {
 	var result flushDepsResult
 
+	finishFlush, err := beginDepFlush(ctx, hash)
+	if err != nil {
+		return result, fmt.Errorf("wait for dependency flush %s: %w", hash, err)
+	}
+	defer finishFlush()
+
 	if err := waitForDepInstall(ctx, hash); err != nil {
 		return result, fmt.Errorf("wait for in-flight dependency install %s: %w", hash, err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -121,6 +121,12 @@ type HealthResponse struct {
 	Version       string `json:"version"`
 }
 
+type flushDepsResult struct {
+	s3DeleteErrors int
+	s3Deleted      int
+	s3ListPages    int
+}
+
 type diskFS struct {
 	basePath     string            // e.g., "/data/cache/5.7.0"
 	hasUserFiles bool              // true if user provided multiple files (v2 mode)
@@ -326,6 +332,8 @@ type versionInfo struct {
 	name    string
 }
 
+const staleDepInstallTempMinAge = time.Hour
+
 // getVersionsByModTime returns version directories sorted by modification time (oldest first)
 func getVersionsByModTime(cachePath string) ([]versionInfo, error) {
 	entries, err := os.ReadDir(cachePath)
@@ -336,6 +344,14 @@ func getVersionsByModTime(cachePath string) ([]versionInfo, error) {
 	var versions []versionInfo
 	for _, entry := range entries {
 		if !entry.IsDir() {
+			continue
+		}
+		if entry.Name() == filepath.Base(depsInstallTempRoot()) {
+			tempVersions, err := getStaleDepInstallTempDirs(cachePath)
+			if err != nil {
+				log.Printf("[CLEANUP] Failed to list dependency install temp dirs: %v", err)
+			}
+			versions = append(versions, tempVersions...)
 			continue
 		}
 
@@ -377,6 +393,47 @@ func getVersionsByModTime(cachePath string) ([]versionInfo, error) {
 	sort.Slice(versions, func(i, j int) bool {
 		return versions[i].modTime.Before(versions[j].modTime)
 	})
+
+	return versions, nil
+}
+
+func getStaleDepInstallTempDirs(cachePath string) ([]versionInfo, error) {
+	tempRootName := filepath.Base(depsInstallTempRoot())
+	tempRoot := filepath.Join(cachePath, tempRootName)
+	entries, err := os.ReadDir(tempRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	activeTempDirs := activeDepInstallTempDirs()
+	staleBefore := time.Now().Add(-staleDepInstallTempMinAge)
+	versions := make([]versionInfo, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		tempDir := filepath.Join(tempRoot, entry.Name())
+		if _, active := activeTempDirs[filepath.Clean(tempDir)]; active {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(staleBefore) {
+			continue
+		}
+
+		versions = append(versions, versionInfo{
+			modTime: info.ModTime(),
+			name:    filepath.Join(tempRootName, entry.Name()),
+		})
+	}
 
 	return versions, nil
 }
@@ -1093,53 +1150,83 @@ func flushDeps(w http.ResponseWriter, req *http.Request) {
 	ctx, span := startSpan(req.Context(), "fly_tsgo.deps.flush")
 	defer span.End()
 
-	// Clear in-flight map
-	depInstallMu.Lock()
-	clear(depInstallInFlight)
-	depInstallMu.Unlock()
+	lockHash := req.URL.Query().Get("lock_hash")
+	if lockHash == "" {
+		lockHash = req.URL.Query().Get("hash")
+	}
+	if lockHash != "" && !isSHA256Hex(lockHash) {
+		http.Error(w, "lock_hash must be a 64-character lowercase hex SHA-256 digest", http.StatusBadRequest)
+		return
+	}
 
-	// Clear disk cache
-	depsPath := filepath.Join(diskCachePath, "deps")
-	if err := os.RemoveAll(depsPath); err != nil {
-		recordSpanError(span, "err-flush-deps-remove-disk", err)
-		log.Printf("[FLUSH] Failed to remove %s: %v", depsPath, err)
+	var result flushDepsResult
+	var err error
+	if lockHash == "" {
+		result, err = flushAllDeps(ctx)
+	} else {
+		span.SetAttributes(attribute.String("fly_tsgo.deps.lock_hash", lockHash))
+		result, err = flushDepsHash(ctx, lockHash)
+	}
+	if err != nil {
+		recordSpanError(span, "err-flush-deps", err)
 		http.Error(w, fmt.Sprintf("failed to flush deps: %v", err), http.StatusInternalServerError)
 		return
 	}
+
+	span.SetAttributes(
+		attribute.Int("fly_tsgo.deps.flush.s3_deleted.count", result.s3Deleted),
+		attribute.Int("fly_tsgo.deps.flush.s3_delete_errors.count", result.s3DeleteErrors),
+		attribute.Int("fly_tsgo.deps.flush.s3_list_pages.count", result.s3ListPages),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	response := map[string]string{"status": "flushed"}
+	if lockHash != "" {
+		response["lock_hash"] = lockHash
+	}
+	json.NewEncoder(w).Encode(response)
+}
+
+func flushAllDeps(ctx context.Context) (flushDepsResult, error) {
+	var result flushDepsResult
+
+	if err := waitForAllDepInstalls(ctx); err != nil {
+		return result, fmt.Errorf("wait for in-flight dependency installs: %w", err)
+	}
+
+	depsPath := filepath.Join(diskCachePath, "deps")
+	if err := os.RemoveAll(depsPath); err != nil {
+		log.Printf("[FLUSH] Failed to remove %s: %v", depsPath, err)
+		return result, fmt.Errorf("remove disk deps cache: %w", err)
+	}
 	log.Printf("[FLUSH] Cleared disk deps cache at %s", depsPath)
 
-	// Clear S3 deps tarballs
 	if s3Client != nil {
-		var deleted int
-		var deleteErrors int
-		var listPages int
 		var continuationToken *string
 		for {
 			input := &s3.ListObjectsV2Input{
 				Bucket: aws.String(s3Bucket),
-				Prefix: aws.String("deps/"),
+				Prefix: aws.String(depsS3Prefix),
 			}
 			if continuationToken != nil {
 				input.ContinuationToken = continuationToken
 			}
 			page, err := s3Client.ListObjectsV2(ctx, input)
 			if err != nil {
-				recordSpanError(span, "err-flush-deps-list-s3", err)
 				log.Printf("[FLUSH] Failed to list S3 deps: %v", err)
 				break
 			}
-			listPages++
+			result.s3ListPages++
 			for _, obj := range page.Contents {
 				if obj.Key != nil {
 					if _, err := s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 						Bucket: aws.String(s3Bucket),
 						Key:    obj.Key,
 					}); err != nil {
-						deleteErrors++
-						recordSpanError(span, "err-flush-deps-delete-s3", err)
+						result.s3DeleteErrors++
 						log.Printf("[FLUSH] Failed to delete S3 object %s: %v", *obj.Key, err)
 					} else {
-						deleted++
+						result.s3Deleted++
 					}
 				}
 			}
@@ -1148,17 +1235,116 @@ func flushDeps(w http.ResponseWriter, req *http.Request) {
 			}
 			continuationToken = page.NextContinuationToken
 		}
-		log.Printf("[FLUSH] Deleted %d S3 deps tarballs", deleted)
+		log.Printf("[FLUSH] Deleted %d S3 deps tarballs", result.s3Deleted)
+	}
+
+	return result, nil
+}
+
+func flushDepsHash(ctx context.Context, hash string) (flushDepsResult, error) {
+	var result flushDepsResult
+
+	if err := waitForDepInstall(ctx, hash); err != nil {
+		return result, fmt.Errorf("wait for in-flight dependency install %s: %w", hash, err)
+	}
+
+	depDir := depsCacheDir(hash)
+	if err := os.RemoveAll(depDir); err != nil {
+		log.Printf("[FLUSH] Failed to remove %s: %v", depDir, err)
+		return result, fmt.Errorf("remove disk deps cache for %s: %w", hash, err)
+	}
+	log.Printf("[FLUSH] Cleared disk deps cache at %s", depDir)
+
+	if s3Client != nil {
+		key := depsCacheS3Key(hash)
+		if _, err := s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: aws.String(s3Bucket),
+			Key:    aws.String(key),
+		}); err != nil {
+			result.s3DeleteErrors++
+			log.Printf("[FLUSH] Failed to delete S3 object %s: %v", key, err)
+		} else {
+			result.s3Deleted++
+		}
+	}
+
+	return result, nil
+}
+
+func isSHA256Hex(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, ch := range value {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func prewarmDeps(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx, span := startSpan(req.Context(), "fly_tsgo.deps.prewarm")
+	defer span.End()
+
+	files, err := parseV3Multipart(req.Body, req.Header.Get("Content-Type"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	pkg, err := parsePackageJSON(files["/package.json"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	lockContent := files["/bun.lock"]
+	if len(lockContent) == 0 {
+		http.Error(w, "missing required file: /bun.lock", http.StatusBadRequest)
+		return
+	}
+
+	lockHash := hashBunLock(lockContent)
+	span.SetAttributes(attribute.String("fly_tsgo.deps.lock_hash", lockHash))
+
+	flushed := req.URL.Query().Get("flush") == "true"
+	if flushed {
+		result, err := flushDepsHash(ctx, lockHash)
+		if err != nil {
+			recordSpanError(span, "err-prewarm-flush-deps", err)
+			http.Error(w, fmt.Sprintf("failed to flush deps: %v", err), http.StatusInternalServerError)
+			return
+		}
 		span.SetAttributes(
-			attribute.Int("fly_tsgo.deps.flush.s3_deleted.count", deleted),
-			attribute.Int("fly_tsgo.deps.flush.s3_delete_errors.count", deleteErrors),
-			attribute.Int("fly_tsgo.deps.flush.s3_list_pages.count", listPages),
+			attribute.Int("fly_tsgo.deps.flush.s3_deleted.count", result.s3Deleted),
+			attribute.Int("fly_tsgo.deps.flush.s3_delete_errors.count", result.s3DeleteErrors),
 		)
 	}
 
+	path, err := resolveDeps(depResolveContext(ctx), lockContent, pkg, files["/package.json"])
+	if err != nil {
+		recordSpanError(span, "err-prewarm-resolve-deps", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":     "dependency installation failed: " + err.Error(),
+			"lock_hash": lockHash,
+		})
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{
-		"status": "flushed",
+	json.NewEncoder(w).Encode(map[string]any{
+		"flushed":   flushed,
+		"lock_hash": lockHash,
+		"path":      path,
+		"status":    "prewarmed",
 	})
 }
 
@@ -1723,6 +1909,7 @@ func main() {
 	registerRoute(mux, "/v2/typecheck", authMiddleware(typecheckV2))
 	registerRoute(mux, "/v3/compile", authMiddleware(compileV3Handler))
 	registerRoute(mux, "/v3/flush-deps", authMiddleware(flushDeps))
+	registerRoute(mux, "/v3/prewarm-deps", authMiddleware(prewarmDeps))
 	registerRoute(mux, "/v3/typecheck", authMiddleware(typecheckV3Handler))
 
 	// Start Prometheus metrics server on port 9091
@@ -1737,7 +1924,7 @@ func main() {
 	// Start server in goroutine
 	go func() {
 		log.Printf("Server ready! Listening on :8080...")
-		log.Printf("Endpoints: /, /build, /health, /sync, /typecheck, /v2/build, /v2/typecheck, /v3/compile, /v3/typecheck")
+		log.Printf("Endpoints: /, /build, /health, /sync, /typecheck, /v2/build, /v2/typecheck, /v3/compile, /v3/flush-deps, /v3/prewarm-deps, /v3/typecheck")
 		log.Printf("Metrics available at :9091/metrics")
 
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/server/server.go
+++ b/server/server.go
@@ -1263,6 +1263,7 @@ func flushDepsHash(ctx context.Context, hash string) (flushDepsResult, error) {
 		}); err != nil {
 			result.s3DeleteErrors++
 			log.Printf("[FLUSH] Failed to delete S3 object %s: %v", key, err)
+			return result, fmt.Errorf("delete S3 deps tarball %s: %w", key, err)
 		} else {
 			result.s3Deleted++
 		}

--- a/server/test_utils.go
+++ b/server/test_utils.go
@@ -16,15 +16,17 @@ import (
 
 // MockS3Client implements a mock S3 client for testing with in-memory files
 type MockS3Client struct {
-	files            map[string]string
-	getObjectCalls   int
-	listObjectsCalls int
-	readFileCalls    []string // Track all file reads for testing
+	deleteObjectErrors map[string]error
+	files              map[string]string
+	getObjectCalls     int
+	listObjectsCalls   int
+	readFileCalls      []string // Track all file reads for testing
 }
 
 func NewMockS3Client() *MockS3Client {
 	m := &MockS3Client{
-		files: make(map[string]string),
+		deleteObjectErrors: make(map[string]error),
+		files:              make(map[string]string),
 	}
 	// Pre-populate with auto-generated package files so ListObjectsV2 returns them
 	m.prePopulatePackages("0.0.4")
@@ -277,6 +279,9 @@ func (m *MockS3Client) ListObjectsV2(ctx context.Context, params *s3.ListObjects
 
 func (m *MockS3Client) DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
 	key := aws.ToString(params.Key)
+	if err := m.deleteObjectErrors[key]; err != nil {
+		return nil, err
+	}
 	delete(m.files, key)
 	return &s3.DeleteObjectOutput{}, nil
 }
@@ -361,6 +366,7 @@ func (m *FileBasedMockS3Client) ListObjectsV2(ctx context.Context, params *s3.Li
 
 		return nil
 	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/server/v3_deps.go
+++ b/server/v3_deps.go
@@ -37,9 +37,12 @@ type depInstallResult struct {
 }
 
 var (
-	depInstallMu       sync.Mutex
-	depInstallInFlight = make(map[string]*depInstallResult)
-	depFlushInFlight   = make(map[string]chan struct{})
+	depInstallMu        sync.Mutex
+	depCacheUseDone     = make(map[string]chan struct{})
+	depCacheUseCounts   = make(map[string]int)
+	depFlushAllInFlight chan struct{}
+	depInstallInFlight  = make(map[string]*depInstallResult)
+	depFlushInFlight    = make(map[string]chan struct{})
 )
 
 func newDepInstallResult() *depInstallResult {
@@ -74,6 +77,14 @@ func depsInstallTempRoot() string {
 //
 // Concurrent requests for the same hash are deduplicated.
 func resolveDeps(ctx context.Context, lockContent []byte, pkg *v3PackageJSON, rawPackageJSON []byte) (string, error) {
+	path, release, err := resolveDepsForUse(ctx, lockContent, pkg, rawPackageJSON)
+	if release != nil {
+		release()
+	}
+	return path, err
+}
+
+func resolveDepsForUse(ctx context.Context, lockContent []byte, pkg *v3PackageJSON, rawPackageJSON []byte) (string, func(), error) {
 	ctx, span := startSpan(ctx, "fly_tsgo.deps.resolve",
 		attribute.Int("fly_tsgo.deps.resolve_s3.count", len(pkg.ResolveS3)),
 	)
@@ -82,26 +93,19 @@ func resolveDeps(ctx context.Context, lockContent []byte, pkg *v3PackageJSON, ra
 	hash := hashBunLock(lockContent)
 	depDir := depsCacheDir(hash)
 
-	if err := waitForDepFlush(ctx, hash); err != nil {
+	release, err := beginDepCacheUse(ctx, hash)
+	if err != nil {
 		recordSpanError(span, "err-deps-flush-wait", err)
-		return "", err
+		return "", nil, err
 	}
+	keepCacheUse := false
+	defer func() {
+		if !keepCacheUse {
+			release()
+		}
+	}()
 
-	// Tier 1: local disk check
-	nmDir := filepath.Join(depDir, "node_modules")
-	if _, err := os.Stat(nmDir); err == nil {
-		depCacheLookups.WithLabelValues("disk_hit").Inc()
-		span.SetAttributes(attribute.String("fly_tsgo.deps.cache.result", "disk_hit"))
-		// Touch mtime for LRU eviction tracking
-		now := time.Now()
-		_ = os.Chtimes(depDir, now, now)
-		return depDir, nil
-	}
-
-	// Concurrency dedup: only one goroutine does the install/download per hash
-	depInstallMu.Lock()
-	if inflight, ok := depInstallInFlight[hash]; ok {
-		depInstallMu.Unlock()
+	waitForInflight := func(inflight *depInstallResult) (string, error) {
 		// Wait until the dependency directory is usable. The full lifecycle may
 		// continue while the cache tarball uploads in the background.
 		if err := waitForDepInstallReady(ctx, inflight); err != nil {
@@ -113,7 +117,49 @@ func resolveDeps(ctx context.Context, lockContent []byte, pkg *v3PackageJSON, ra
 			attribute.Bool("fly_tsgo.deps.wait_inflight.success", inflight.err == nil),
 		)
 		recordSpanError(span, "err-deps-inflight", inflight.err)
-		return inflight.path, inflight.err
+		if inflight.err != nil {
+			return "", inflight.err
+		}
+		return inflight.path, nil
+	}
+
+	// Check active publishers before trusting disk. S3 extraction and copy
+	// fallback publish incrementally, so a visible node_modules directory is
+	// not complete while an in-flight result exists for the same hash.
+	depInstallMu.Lock()
+	inflight := depInstallInFlight[hash]
+	depInstallMu.Unlock()
+	if inflight != nil {
+		path, err := waitForInflight(inflight)
+		if err != nil {
+			return "", nil, err
+		}
+		keepCacheUse = true
+		return path, release, nil
+	}
+
+	// Tier 1: local disk check
+	nmDir := filepath.Join(depDir, "node_modules")
+	if _, err := os.Stat(nmDir); err == nil {
+		depCacheLookups.WithLabelValues("disk_hit").Inc()
+		span.SetAttributes(attribute.String("fly_tsgo.deps.cache.result", "disk_hit"))
+		// Touch mtime for LRU eviction tracking
+		now := time.Now()
+		_ = os.Chtimes(depDir, now, now)
+		keepCacheUse = true
+		return depDir, release, nil
+	}
+
+	// Concurrency dedup: only one goroutine does the install/download per hash
+	depInstallMu.Lock()
+	if inflight, ok := depInstallInFlight[hash]; ok {
+		depInstallMu.Unlock()
+		path, err := waitForInflight(inflight)
+		if err != nil {
+			return "", nil, err
+		}
+		keepCacheUse = true
+		return path, release, nil
 	}
 	result := newDepInstallResult()
 	depInstallInFlight[hash] = result
@@ -146,7 +192,11 @@ func resolveDeps(ctx context.Context, lockContent []byte, pkg *v3PackageJSON, ra
 	close(result.ready)
 	finishDepInstallAsync(ctx, hash, result, uploadAfterReady)
 
-	return path, err
+	if err != nil {
+		return "", nil, err
+	}
+	keepCacheUse = true
+	return path, release, nil
 }
 
 func finishDepInstallAsync(ctx context.Context, hash string, result *depInstallResult, uploadAfterReady bool) {
@@ -200,9 +250,64 @@ func waitForDepInstall(ctx context.Context, hash string) error {
 	return waitForDepInstallResult(ctx, inflight)
 }
 
+func beginDepCacheUse(ctx context.Context, hash string) (func(), error) {
+	for {
+		depInstallMu.Lock()
+		if done := depFlushAllInFlight; done != nil {
+			depInstallMu.Unlock()
+			if err := waitForClosed(ctx, done); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if done := depFlushInFlight[hash]; done != nil {
+			depInstallMu.Unlock()
+			if err := waitForClosed(ctx, done); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		depCacheUseCounts[hash]++
+		released := false
+		depInstallMu.Unlock()
+
+		return func() {
+			depInstallMu.Lock()
+			if released {
+				depInstallMu.Unlock()
+				return
+			}
+			released = true
+
+			count := depCacheUseCounts[hash] - 1
+			var done chan struct{}
+			if count <= 0 {
+				delete(depCacheUseCounts, hash)
+				done = depCacheUseDone[hash]
+				delete(depCacheUseDone, hash)
+			} else {
+				depCacheUseCounts[hash] = count
+			}
+			depInstallMu.Unlock()
+
+			if done != nil {
+				close(done)
+			}
+		}, nil
+	}
+}
+
 func beginDepFlush(ctx context.Context, hash string) (func(), error) {
 	for {
 		depInstallMu.Lock()
+		if done := depFlushAllInFlight; done != nil {
+			depInstallMu.Unlock()
+			if err := waitForClosed(ctx, done); err != nil {
+				return nil, err
+			}
+			continue
+		}
 		if done, ok := depFlushInFlight[hash]; ok {
 			depInstallMu.Unlock()
 			if err := waitForClosed(ctx, done); err != nil {
@@ -229,12 +334,82 @@ func beginDepFlush(ctx context.Context, hash string) (func(), error) {
 	}
 }
 
-func waitForDepFlush(ctx context.Context, hash string) error {
+func beginDepFlushAll(ctx context.Context) (func(), error) {
 	for {
 		depInstallMu.Lock()
-		done := depFlushInFlight[hash]
+		if done := depFlushAllInFlight; done != nil {
+			depInstallMu.Unlock()
+			if err := waitForClosed(ctx, done); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		var activeFlushDone chan struct{}
+		for _, done := range depFlushInFlight {
+			activeFlushDone = done
+			break
+		}
+		if activeFlushDone != nil {
+			depInstallMu.Unlock()
+			if err := waitForClosed(ctx, activeFlushDone); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		done := make(chan struct{})
+		depFlushAllInFlight = done
+		depInstallMu.Unlock()
+
+		return func() {
+			depInstallMu.Lock()
+			current := depFlushAllInFlight
+			if current == done {
+				depFlushAllInFlight = nil
+			}
+			depInstallMu.Unlock()
+			if current == done {
+				close(done)
+			}
+		}, nil
+	}
+}
+
+func waitForAllDepCacheUse(ctx context.Context) error {
+	for {
+		depInstallMu.Lock()
+		var done chan struct{}
+		for hash, count := range depCacheUseCounts {
+			if count > 0 {
+				done = depCacheUseDone[hash]
+				if done == nil {
+					done = make(chan struct{})
+					depCacheUseDone[hash] = done
+				}
+				break
+			}
+		}
 		depInstallMu.Unlock()
 		if done == nil {
+			return nil
+		}
+		if err := waitForClosed(ctx, done); err != nil {
+			return err
+		}
+	}
+}
+
+func waitForDepCacheUse(ctx context.Context, hash string) error {
+	for {
+		depInstallMu.Lock()
+		count := depCacheUseCounts[hash]
+		done := depCacheUseDone[hash]
+		if count > 0 && done == nil {
+			done = make(chan struct{})
+			depCacheUseDone[hash] = done
+		}
+		depInstallMu.Unlock()
+		if count == 0 {
 			return nil
 		}
 		if err := waitForClosed(ctx, done); err != nil {

--- a/server/v3_deps.go
+++ b/server/v3_deps.go
@@ -39,6 +39,7 @@ type depInstallResult struct {
 var (
 	depInstallMu       sync.Mutex
 	depInstallInFlight = make(map[string]*depInstallResult)
+	depFlushInFlight   = make(map[string]chan struct{})
 )
 
 func newDepInstallResult() *depInstallResult {
@@ -80,6 +81,11 @@ func resolveDeps(ctx context.Context, lockContent []byte, pkg *v3PackageJSON, ra
 
 	hash := hashBunLock(lockContent)
 	depDir := depsCacheDir(hash)
+
+	if err := waitForDepFlush(ctx, hash); err != nil {
+		recordSpanError(span, "err-deps-flush-wait", err)
+		return "", err
+	}
 
 	// Tier 1: local disk check
 	nmDir := filepath.Join(depDir, "node_modules")
@@ -192,6 +198,58 @@ func waitForDepInstall(ctx context.Context, hash string) error {
 	}
 
 	return waitForDepInstallResult(ctx, inflight)
+}
+
+func beginDepFlush(ctx context.Context, hash string) (func(), error) {
+	for {
+		depInstallMu.Lock()
+		if done, ok := depFlushInFlight[hash]; ok {
+			depInstallMu.Unlock()
+			if err := waitForClosed(ctx, done); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		done := make(chan struct{})
+		depFlushInFlight[hash] = done
+		depInstallMu.Unlock()
+
+		return func() {
+			depInstallMu.Lock()
+			current := depFlushInFlight[hash]
+			if current == done {
+				delete(depFlushInFlight, hash)
+			}
+			depInstallMu.Unlock()
+			if current == done {
+				close(done)
+			}
+		}, nil
+	}
+}
+
+func waitForDepFlush(ctx context.Context, hash string) error {
+	for {
+		depInstallMu.Lock()
+		done := depFlushInFlight[hash]
+		depInstallMu.Unlock()
+		if done == nil {
+			return nil
+		}
+		if err := waitForClosed(ctx, done); err != nil {
+			return err
+		}
+	}
+}
+
+func waitForClosed(ctx context.Context, done <-chan struct{}) error {
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func waitForDepInstallReady(ctx context.Context, result *depInstallResult) error {

--- a/server/v3_deps.go
+++ b/server/v3_deps.go
@@ -325,12 +325,13 @@ func installDeps(ctx context.Context, hash string, depDir string, lockContent []
 		return "", fmt.Errorf("remove stale depDir: %w", err)
 	}
 
-	// Attempt rename first (fast if same filesystem), fall back to copy
-	if err := os.Rename(filepath.Join(tmpDir), depDir); err != nil {
-		if err2 := os.MkdirAll(depDir, 0o755); err2 != nil {
-			recordSpanError(span, "err-deps-mkdir-cache-dir", err2)
-			return "", fmt.Errorf("mkdir depDir: %w", err2)
-		}
+	if err := os.MkdirAll(depDir, 0o755); err != nil {
+		recordSpanError(span, "err-deps-mkdir-cache-dir", err)
+		return "", fmt.Errorf("mkdir depDir: %w", err)
+	}
+
+	// Attempt rename first (fast if same filesystem), fall back to copy.
+	if err := os.Rename(tmpNM, destNM); err != nil {
 		if err2 := copyDir(tmpNM, destNM); err2 != nil {
 			recordSpanError(span, "err-deps-copy-node-modules", err2)
 			return "", fmt.Errorf("copy node_modules: %w", err2)

--- a/server/v3_deps.go
+++ b/server/v3_deps.go
@@ -24,12 +24,16 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const depsS3Prefix = "deps/"
+
 // depInstallResult holds the outcome of a dep install operation.
 // Multiple concurrent requests for the same hash share one result.
 type depInstallResult struct {
-	done chan struct{}
-	err  error
-	path string
+	done    chan struct{}
+	err     error
+	path    string
+	ready   chan struct{}
+	tempDir string
 }
 
 var (
@@ -37,10 +41,29 @@ var (
 	depInstallInFlight = make(map[string]*depInstallResult)
 )
 
+func newDepInstallResult() *depInstallResult {
+	return &depInstallResult{
+		done:  make(chan struct{}),
+		ready: make(chan struct{}),
+	}
+}
+
 // hashBunLock returns the SHA256 hex digest of the bun.lock content.
 func hashBunLock(lockContent []byte) string {
 	sum := sha256.Sum256(lockContent)
 	return hex.EncodeToString(sum[:])
+}
+
+func depsCacheDir(hash string) string {
+	return filepath.Join(diskCachePath, "deps", hash)
+}
+
+func depsCacheS3Key(hash string) string {
+	return depsS3Prefix + hash + ".tar.gz"
+}
+
+func depsInstallTempRoot() string {
+	return filepath.Join(diskCachePath, ".deps-tmp")
 }
 
 // resolveDeps resolves dependencies using a 3-tier lookup:
@@ -56,7 +79,7 @@ func resolveDeps(ctx context.Context, lockContent []byte, pkg *v3PackageJSON, ra
 	defer span.End()
 
 	hash := hashBunLock(lockContent)
-	depDir := filepath.Join(diskCachePath, "deps", hash)
+	depDir := depsCacheDir(hash)
 
 	// Tier 1: local disk check
 	nmDir := filepath.Join(depDir, "node_modules")
@@ -73,8 +96,12 @@ func resolveDeps(ctx context.Context, lockContent []byte, pkg *v3PackageJSON, ra
 	depInstallMu.Lock()
 	if inflight, ok := depInstallInFlight[hash]; ok {
 		depInstallMu.Unlock()
-		// Wait for the in-flight install to complete
-		<-inflight.done
+		// Wait until the dependency directory is usable. The full lifecycle may
+		// continue while the cache tarball uploads in the background.
+		if err := waitForDepInstallReady(ctx, inflight); err != nil {
+			recordSpanError(span, "err-deps-inflight-wait", err)
+			return "", err
+		}
 		span.SetAttributes(
 			attribute.String("fly_tsgo.deps.cache.result", "inflight"),
 			attribute.Bool("fly_tsgo.deps.wait_inflight.success", inflight.err == nil),
@@ -82,13 +109,12 @@ func resolveDeps(ctx context.Context, lockContent []byte, pkg *v3PackageJSON, ra
 		recordSpanError(span, "err-deps-inflight", inflight.err)
 		return inflight.path, inflight.err
 	}
-	result := &depInstallResult{
-		done: make(chan struct{}),
-	}
+	result := newDepInstallResult()
 	depInstallInFlight[hash] = result
 	depInstallMu.Unlock()
 
 	// Perform the resolution (S3 then bun install)
+	uploadAfterReady := false
 	path, err := func() (string, error) {
 		// Tier 2: S3 lookup
 		if s3Client != nil {
@@ -103,26 +129,114 @@ func resolveDeps(ctx context.Context, lockContent []byte, pkg *v3PackageJSON, ra
 		// Tier 3: bun install
 		depCacheLookups.WithLabelValues("install").Inc()
 		span.SetAttributes(attribute.String("fly_tsgo.deps.cache.result", "install"))
-		return installDeps(ctx, hash, depDir, lockContent, pkg, rawPackageJSON)
+		uploadAfterReady = true
+		return installDeps(ctx, hash, depDir, lockContent, pkg, rawPackageJSON, result)
 	}()
 	recordSpanError(span, "err-deps-resolve", err)
 
-	// Broadcast result to all waiters
+	// Broadcast the usable dependency directory to compile/typecheck waiters.
 	result.path = path
 	result.err = err
-	close(result.done)
-
-	// Remove from in-flight map
-	depInstallMu.Lock()
-	delete(depInstallInFlight, hash)
-	depInstallMu.Unlock()
+	close(result.ready)
+	finishDepInstallAsync(ctx, hash, result, uploadAfterReady)
 
 	return path, err
 }
 
+func finishDepInstallAsync(ctx context.Context, hash string, result *depInstallResult, uploadAfterReady bool) {
+	if result.err != nil || result.path == "" || !uploadAfterReady {
+		closeDepInstallResult(hash, result)
+		return
+	}
+
+	go func() {
+		uploadDepsToS3(ctx, hash, result.path)
+		closeDepInstallResult(hash, result)
+	}()
+}
+
+func closeDepInstallResult(hash string, result *depInstallResult) {
+	depInstallMu.Lock()
+	if depInstallInFlight[hash] == result {
+		delete(depInstallInFlight, hash)
+	}
+	depInstallMu.Unlock()
+
+	close(result.done)
+}
+
+func waitForAllDepInstalls(ctx context.Context) error {
+	depInstallMu.Lock()
+	inflights := make([]*depInstallResult, 0, len(depInstallInFlight))
+	for _, inflight := range depInstallInFlight {
+		inflights = append(inflights, inflight)
+	}
+	depInstallMu.Unlock()
+
+	for _, inflight := range inflights {
+		if err := waitForDepInstallResult(ctx, inflight); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func waitForDepInstall(ctx context.Context, hash string) error {
+	depInstallMu.Lock()
+	inflight := depInstallInFlight[hash]
+	depInstallMu.Unlock()
+
+	if inflight == nil {
+		return nil
+	}
+
+	return waitForDepInstallResult(ctx, inflight)
+}
+
+func waitForDepInstallReady(ctx context.Context, result *depInstallResult) error {
+	select {
+	case <-result.ready:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func waitForDepInstallResult(ctx context.Context, result *depInstallResult) error {
+	select {
+	case <-result.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func activeDepInstallTempDirs() map[string]struct{} {
+	depInstallMu.Lock()
+	defer depInstallMu.Unlock()
+
+	active := make(map[string]struct{}, len(depInstallInFlight))
+	for _, inflight := range depInstallInFlight {
+		if inflight.tempDir != "" {
+			active[filepath.Clean(inflight.tempDir)] = struct{}{}
+		}
+	}
+	return active
+}
+
+func setDepInstallTempDir(result *depInstallResult, tmpDir string) {
+	if result == nil {
+		return
+	}
+	depInstallMu.Lock()
+	result.tempDir = tmpDir
+	depInstallMu.Unlock()
+}
+
 // resolveDepsFromS3 downloads and extracts a deps tarball from S3.
 func resolveDepsFromS3(ctx context.Context, hash string, depDir string) (string, error) {
-	key := "deps/" + hash + ".tar.gz"
+	key := depsCacheS3Key(hash)
 	out, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(s3Bucket),
 		Key:    aws.String(key),
@@ -143,19 +257,25 @@ func resolveDepsFromS3(ctx context.Context, hash string, depDir string) (string,
 	return depDir, nil
 }
 
-// installDeps runs bun install in a temp dir, moves the result to the cache,
-// and uploads the tarball to S3 in the background.
-func installDeps(ctx context.Context, hash string, depDir string, lockContent []byte, pkg *v3PackageJSON, rawPackageJSON []byte) (string, error) {
+// installDeps runs bun install in a temp dir and moves the result to the cache.
+func installDeps(ctx context.Context, hash string, depDir string, lockContent []byte, pkg *v3PackageJSON, rawPackageJSON []byte, result *depInstallResult) (string, error) {
 	ctx, span := startSpan(ctx, "fly_tsgo.deps.install",
 		attribute.Int("fly_tsgo.deps.resolve_s3.count", len(pkg.ResolveS3)),
 	)
 	defer span.End()
 	start := time.Now()
 
-	tmpDir, err := os.MkdirTemp("", "bun-install-*")
+	tmpRoot := depsInstallTempRoot()
+	if err := os.MkdirAll(tmpRoot, 0755); err != nil {
+		return "", fmt.Errorf("mkdir temp root: %w", err)
+	}
+
+	tmpDir, err := os.MkdirTemp(tmpRoot, "bun-install-*")
 	if err != nil {
 		return "", fmt.Errorf("mkdirtemp: %w", err)
 	}
+	setDepInstallTempDir(result, tmpDir)
+	defer setDepInstallTempDir(result, "")
 	defer os.RemoveAll(tmpDir)
 
 	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), rawPackageJSON, 0o644); err != nil {
@@ -200,6 +320,11 @@ func installDeps(ctx context.Context, hash string, depDir string, lockContent []
 	tmpNM := filepath.Join(tmpDir, "node_modules")
 	destNM := filepath.Join(depDir, "node_modules")
 
+	if err := os.RemoveAll(depDir); err != nil {
+		recordSpanError(span, "err-deps-remove-stale-cache-dir", err)
+		return "", fmt.Errorf("remove stale depDir: %w", err)
+	}
+
 	// Attempt rename first (fast if same filesystem), fall back to copy
 	if err := os.Rename(filepath.Join(tmpDir), depDir); err != nil {
 		if err2 := os.MkdirAll(depDir, 0o755); err2 != nil {
@@ -211,10 +336,9 @@ func installDeps(ctx context.Context, hash string, depDir string, lockContent []
 			return "", fmt.Errorf("copy node_modules: %w", err2)
 		}
 		span.SetAttributes(attribute.Bool("fly_tsgo.deps.cache.copied", true))
+	} else {
+		span.SetAttributes(attribute.Bool("fly_tsgo.deps.cache.copied", false))
 	}
-
-	// Upload to S3 in background without inheriting request cancellation.
-	go uploadDepsToS3(ctx, hash, depDir)
 
 	return depDir, nil
 }

--- a/server/v3_handlers.go
+++ b/server/v3_handlers.go
@@ -26,7 +26,7 @@ func typecheckV3Handler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	lockContent := files["/bun.lock"]
-	depPath, err := resolveDeps(depResolveContext(ctx), lockContent, pkg, files["/package.json"])
+	depPath, releaseDeps, err := resolveDepsForUse(depResolveContext(ctx), lockContent, pkg, files["/package.json"])
 	if err != nil {
 		log.Printf("[V3] Dep resolution failed: %v", err)
 		w.Header().Set("Content-Type", "application/json")
@@ -36,6 +36,7 @@ func typecheckV3Handler(w http.ResponseWriter, req *http.Request) {
 		})
 		return
 	}
+	defer releaseDeps()
 	_ = depPath
 
 	var tsconfigRaw []byte
@@ -73,7 +74,7 @@ func compileV3Handler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	lockContent := files["/bun.lock"]
-	depPath, err := resolveDeps(depResolveContext(ctx), lockContent, pkg, files["/package.json"])
+	depPath, releaseDeps, err := resolveDepsForUse(depResolveContext(ctx), lockContent, pkg, files["/package.json"])
 	if err != nil {
 		log.Printf("[V3] Dep resolution failed: %v", err)
 		w.Header().Set("Content-Type", "application/json")
@@ -83,6 +84,7 @@ func compileV3Handler(w http.ResponseWriter, req *http.Request) {
 		})
 		return
 	}
+	defer releaseDeps()
 	_ = depPath
 
 	var tsconfigRaw []byte

--- a/server/v3_test.go
+++ b/server/v3_test.go
@@ -627,6 +627,55 @@ func TestResolveDeps_S3Hit(t *testing.T) {
 	}
 }
 
+func TestInstallDeps_CachesOnlyNodeModules(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "deps-install-cache-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	diskCachePath = tmpDir
+
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	fakeBun := filepath.Join(binDir, "bun")
+	if err := os.WriteFile(fakeBun, []byte("#!/bin/sh\nmkdir -p node_modules/zod\nprintf 'module.exports = {}\\n' > node_modules/zod/index.js\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	lockContent := []byte("install cache test lockfile")
+	hash := hashBunLock(lockContent)
+	depDir := depsCacheDir(hash)
+	pkg := &v3PackageJSON{Dependencies: map[string]string{"zod": "3.23.0"}}
+
+	path, err := installDeps(
+		context.Background(),
+		hash,
+		depDir,
+		lockContent,
+		pkg,
+		[]byte(`{"dependencies":{"zod":"3.23.0"},"type":"module"}`),
+		newDepInstallResult(),
+	)
+	if err != nil {
+		t.Fatalf("installDeps failed: %v", err)
+	}
+	if path != depDir {
+		t.Fatalf("expected %s, got %s", depDir, path)
+	}
+	if _, err := os.Stat(filepath.Join(depDir, "node_modules", "zod", "index.js")); err != nil {
+		t.Fatalf("node_modules should be cached: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(depDir, "package.json")); !os.IsNotExist(err) {
+		t.Fatalf("package.json should not be cached, stat err: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(depDir, "bun.lock")); !os.IsNotExist(err) {
+		t.Fatalf("bun.lock should not be cached, stat err: %v", err)
+	}
+}
+
 // Task 8: typecheckV3 tests
 
 func TestTypecheckV3_PassingCode(t *testing.T) {

--- a/server/v3_test.go
+++ b/server/v3_test.go
@@ -2639,3 +2639,370 @@ func TestFlushDeps_ClearsDiskAndS3(t *testing.T) {
 		t.Fatalf("S3 deps tarball should be deleted after flush")
 	}
 }
+
+func TestFlushAllDeps_PreservesInstallTempRoot(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "flush-temp-root-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	diskCachePath = tmpDir
+	s3Client = nil
+	resetDepInstallInFlightForTest(t)
+
+	depDir := filepath.Join(diskCachePath, "deps", "hash", "node_modules", "zod")
+	if err := os.MkdirAll(depDir, 0755); err != nil {
+		t.Fatalf("seed dep dir: %v", err)
+	}
+	activeTmpDir := filepath.Join(depsInstallTempRoot(), "bun-install-active")
+	if err := os.MkdirAll(activeTmpDir, 0755); err != nil {
+		t.Fatalf("seed active temp dir: %v", err)
+	}
+
+	if _, err := flushAllDeps(context.Background()); err != nil {
+		t.Fatalf("flush all deps: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(diskCachePath, "deps")); !os.IsNotExist(err) {
+		t.Fatalf("disk deps dir should be deleted after flush")
+	}
+	if _, err := os.Stat(activeTmpDir); err != nil {
+		t.Fatalf("active install temp dir should remain outside deps flush tree: %v", err)
+	}
+}
+
+func TestDeleteOldestVersion_ReclaimsStaleInstallTempDir(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "stale-install-temp-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	diskCachePath = tmpDir
+	s3Client = nil
+	resetDepInstallInFlightForTest(t)
+
+	staleTmpDir := filepath.Join(depsInstallTempRoot(), "bun-install-stale")
+	activeTmpDir := filepath.Join(depsInstallTempRoot(), "bun-install-active")
+	freshTmpDir := filepath.Join(depsInstallTempRoot(), "bun-install-fresh")
+	for _, dir := range []string{staleTmpDir, activeTmpDir, freshTmpDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("seed temp dir %s: %v", dir, err)
+		}
+	}
+
+	oldTime := time.Now().Add(-2 * staleDepInstallTempMinAge)
+	if err := os.Chtimes(staleTmpDir, oldTime, oldTime); err != nil {
+		t.Fatalf("age stale temp dir: %v", err)
+	}
+	if err := os.Chtimes(activeTmpDir, oldTime, oldTime); err != nil {
+		t.Fatalf("age active temp dir: %v", err)
+	}
+
+	inflight := newDepInstallResult()
+	setDepInstallTempDir(inflight, activeTmpDir)
+	depInstallMu.Lock()
+	depInstallInFlight["active"] = inflight
+	depInstallMu.Unlock()
+
+	if !deleteOldestVersion("") {
+		t.Fatal("expected stale install temp dir to be reclaimed")
+	}
+
+	if _, err := os.Stat(staleTmpDir); !os.IsNotExist(err) {
+		t.Fatalf("stale install temp dir should be deleted")
+	}
+	if _, err := os.Stat(activeTmpDir); err != nil {
+		t.Fatalf("active install temp dir should remain: %v", err)
+	}
+	if _, err := os.Stat(freshTmpDir); err != nil {
+		t.Fatalf("fresh install temp dir should remain: %v", err)
+	}
+}
+
+func TestFlushDeps_TargetedHashClearsOnlyThatHash(t *testing.T) {
+	mockS3 := setupTestServerWithMockS3(t)
+
+	lockA := []byte("targeted-flush-lock-a")
+	lockB := []byte("targeted-flush-lock-b")
+	hashA := hashBunLock(lockA)
+	hashB := hashBunLock(lockB)
+
+	depA := filepath.Join(diskCachePath, "deps", hashA, "node_modules", "a")
+	depB := filepath.Join(diskCachePath, "deps", hashB, "node_modules", "b")
+	if err := os.MkdirAll(depA, 0755); err != nil {
+		t.Fatalf("seed dep A: %v", err)
+	}
+	if err := os.MkdirAll(depB, 0755); err != nil {
+		t.Fatalf("seed dep B: %v", err)
+	}
+
+	keyA := depsCacheS3Key(hashA)
+	keyB := depsCacheS3Key(hashB)
+	mockS3.files[keyA] = "cached-a"
+	mockS3.files[keyB] = "cached-b"
+
+	req := httptest.NewRequest(http.MethodPost, "/v3/flush-deps?lock_hash="+hashA, nil)
+	w := httptest.NewRecorder()
+	flushDeps(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	if _, err := os.Stat(filepath.Join(diskCachePath, "deps", hashA)); !os.IsNotExist(err) {
+		t.Fatalf("targeted disk deps dir should be deleted")
+	}
+	if _, err := os.Stat(depB); err != nil {
+		t.Fatalf("other disk deps dir should remain: %v", err)
+	}
+	if _, exists := mockS3.files[keyA]; exists {
+		t.Fatalf("targeted S3 deps tarball should be deleted")
+	}
+	if _, exists := mockS3.files[keyB]; !exists {
+		t.Fatalf("other S3 deps tarball should remain")
+	}
+}
+
+func TestFlushDepsHash_WaitsForInFlightInstall(t *testing.T) {
+	mockS3 := setupTestServerWithMockS3(t)
+	resetDepInstallInFlightForTest(t)
+
+	lockContent := []byte("targeted-flush-inflight-lock")
+	hash := hashBunLock(lockContent)
+	depDir := filepath.Join(diskCachePath, "deps", hash)
+	if err := os.MkdirAll(filepath.Join(depDir, "node_modules", "zod"), 0755); err != nil {
+		t.Fatalf("seed dep dir: %v", err)
+	}
+	key := depsCacheS3Key(hash)
+	mockS3.files[key] = "cached"
+
+	inflight := newDepInstallResult()
+	depInstallMu.Lock()
+	depInstallInFlight[hash] = inflight
+	depInstallMu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := flushDepsHash(context.Background(), hash)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("flush returned before in-flight install completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	if _, err := os.Stat(depDir); err != nil {
+		t.Fatalf("dep dir should remain while in-flight install is active: %v", err)
+	}
+	if _, exists := mockS3.files[key]; !exists {
+		t.Fatalf("S3 deps tarball should remain while in-flight install is active")
+	}
+
+	close(inflight.done)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("flush after in-flight install: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("flush did not finish after in-flight install completed")
+	}
+
+	if _, err := os.Stat(depDir); !os.IsNotExist(err) {
+		t.Fatalf("dep dir should be deleted after in-flight install completes")
+	}
+	if _, exists := mockS3.files[key]; exists {
+		t.Fatalf("S3 deps tarball should be deleted after in-flight install completes")
+	}
+}
+
+func TestFlushDepsHash_WaitsForInFlightUpload(t *testing.T) {
+	mockS3 := setupTestServerWithMockS3(t)
+	resetDepInstallInFlightForTest(t)
+
+	lockContent := []byte("targeted-flush-upload-lock")
+	hash := hashBunLock(lockContent)
+	depDir := filepath.Join(diskCachePath, "deps", hash)
+	if err := os.MkdirAll(filepath.Join(depDir, "node_modules", "zod"), 0755); err != nil {
+		t.Fatalf("seed dep dir: %v", err)
+	}
+	key := depsCacheS3Key(hash)
+	mockS3.files[key] = "cached"
+
+	inflight := newDepInstallResult()
+	inflight.path = depDir
+	close(inflight.ready)
+	depInstallMu.Lock()
+	depInstallInFlight[hash] = inflight
+	depInstallMu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := flushDepsHash(context.Background(), hash)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("flush returned before in-flight upload completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	if _, err := os.Stat(depDir); err != nil {
+		t.Fatalf("dep dir should remain while upload is active: %v", err)
+	}
+	if _, exists := mockS3.files[key]; !exists {
+		t.Fatalf("S3 deps tarball should remain while upload is active")
+	}
+
+	close(inflight.done)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("flush after in-flight upload: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("flush did not finish after in-flight upload completed")
+	}
+
+	if _, err := os.Stat(depDir); !os.IsNotExist(err) {
+		t.Fatalf("dep dir should be deleted after in-flight upload completes")
+	}
+	if _, exists := mockS3.files[key]; exists {
+		t.Fatalf("S3 deps tarball should be deleted after in-flight upload completes")
+	}
+}
+
+func TestCloseDepInstallResult_RemovesEntryBeforeWakingWaiters(t *testing.T) {
+	resetDepInstallInFlightForTest(t)
+
+	hash := hashBunLock([]byte("close-before-wake"))
+	inflight := newDepInstallResult()
+	depInstallMu.Lock()
+	depInstallInFlight[hash] = inflight
+	depInstallMu.Unlock()
+
+	depInstallMu.Lock()
+	closed := make(chan struct{})
+	go func() {
+		closeDepInstallResult(hash, inflight)
+		close(closed)
+	}()
+
+	select {
+	case <-inflight.done:
+		t.Fatal("install result woke waiters before removing the in-flight entry")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	depInstallMu.Unlock()
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("closeDepInstallResult did not finish")
+	}
+
+	select {
+	case <-inflight.done:
+	case <-time.After(time.Second):
+		t.Fatal("install result did not wake waiters")
+	}
+
+	depInstallMu.Lock()
+	_, exists := depInstallInFlight[hash]
+	depInstallMu.Unlock()
+	if exists {
+		t.Fatal("in-flight entry should be removed after close")
+	}
+}
+
+func TestPrewarmDeps_ResolvesDependencyCache(t *testing.T) {
+	mockS3 := setupTestServerWithMockS3(t)
+
+	lockContent := []byte("prewarm-test-lockfile")
+	hash := hashBunLock(lockContent)
+	seedDepsTarball(t, mockS3, depsCacheS3Key(hash), "node_modules/zod/index.js", []byte("module.exports = {}"))
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("/bun.lock", string(lockContent)); err != nil {
+		t.Fatalf("write bun.lock field: %v", err)
+	}
+	if err := writer.WriteField("/package.json", `{"dependencies":{"zod":"3.23.0"}}`); err != nil {
+		t.Fatalf("write package.json field: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v3/prewarm-deps", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	w := httptest.NewRecorder()
+	prewarmDeps(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var response map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response["status"] != "prewarmed" {
+		t.Fatalf("expected prewarmed status, got %#v", response["status"])
+	}
+	if response["lock_hash"] != hash {
+		t.Fatalf("expected lock_hash %s, got %#v", hash, response["lock_hash"])
+	}
+	if _, err := os.Stat(filepath.Join(diskCachePath, "deps", hash, "node_modules", "zod", "index.js")); err != nil {
+		t.Fatalf("disk cache should be populated after prewarm: %v", err)
+	}
+}
+
+func seedDepsTarball(t *testing.T, mockS3 *MockS3Client, key string, name string, content []byte) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0644,
+		Size: int64(len(content)),
+	}); err != nil {
+		t.Fatalf("write tar header: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("write tar content: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	mockS3.files[key] = buf.String()
+}
+
+func resetDepInstallInFlightForTest(t *testing.T) {
+	t.Helper()
+	depInstallMu.Lock()
+	previous := depInstallInFlight
+	depInstallInFlight = make(map[string]*depInstallResult)
+	depInstallMu.Unlock()
+
+	t.Cleanup(func() {
+		depInstallMu.Lock()
+		depInstallInFlight = previous
+		depInstallMu.Unlock()
+	})
+}

--- a/server/v3_test.go
+++ b/server/v3_test.go
@@ -2928,6 +2928,122 @@ func TestFlushDepsHash_WaitsForInFlightUpload(t *testing.T) {
 	}
 }
 
+func TestFlushDepsHash_WaitsForActiveCacheUse(t *testing.T) {
+	mockS3 := setupTestServerWithMockS3(t)
+	resetDepInstallInFlightForTest(t)
+
+	lockContent := []byte("targeted-flush-active-cache-use")
+	hash := hashBunLock(lockContent)
+	depDir := filepath.Join(diskCachePath, "deps", hash)
+	if err := os.MkdirAll(filepath.Join(depDir, "node_modules", "zod"), 0755); err != nil {
+		t.Fatalf("seed dep dir: %v", err)
+	}
+	key := depsCacheS3Key(hash)
+	mockS3.files[key] = "cached"
+
+	pkg := &v3PackageJSON{Dependencies: map[string]string{"zod": "3.23.0"}}
+	path, release, err := resolveDepsForUse(context.Background(), lockContent, pkg, []byte(`{"dependencies":{"zod":"3.23.0"}}`))
+	if err != nil {
+		t.Fatalf("resolve deps: %v", err)
+	}
+	if path != depDir {
+		t.Fatalf("expected dep path %s, got %s", depDir, path)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := flushDepsHash(context.Background(), hash)
+		done <- err
+	}()
+
+	waitForFlushInFlightForTest(t, hash)
+
+	select {
+	case err := <-done:
+		t.Fatalf("flush returned before cache use was released: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	if _, err := os.Stat(depDir); err != nil {
+		t.Fatalf("dep dir should remain while cache use is active: %v", err)
+	}
+	if _, exists := mockS3.files[key]; !exists {
+		t.Fatalf("S3 deps tarball should remain while cache use is active")
+	}
+
+	release()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("flush after cache use release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("flush did not finish after cache use was released")
+	}
+
+	if _, err := os.Stat(depDir); !os.IsNotExist(err) {
+		t.Fatalf("dep dir should be deleted after cache use is released")
+	}
+	if _, exists := mockS3.files[key]; exists {
+		t.Fatalf("S3 deps tarball should be deleted after cache use is released")
+	}
+}
+
+func TestFlushAllDeps_WaitsForActiveCacheUse(t *testing.T) {
+	setupTestServerWithMockS3(t)
+	resetDepInstallInFlightForTest(t)
+
+	lockContent := []byte("global-flush-active-cache-use")
+	hash := hashBunLock(lockContent)
+	depDir := filepath.Join(diskCachePath, "deps", hash)
+	if err := os.MkdirAll(filepath.Join(depDir, "node_modules", "zod"), 0755); err != nil {
+		t.Fatalf("seed dep dir: %v", err)
+	}
+
+	pkg := &v3PackageJSON{Dependencies: map[string]string{"zod": "3.23.0"}}
+	path, release, err := resolveDepsForUse(context.Background(), lockContent, pkg, []byte(`{"dependencies":{"zod":"3.23.0"}}`))
+	if err != nil {
+		t.Fatalf("resolve deps: %v", err)
+	}
+	if path != depDir {
+		t.Fatalf("expected dep path %s, got %s", depDir, path)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := flushAllDeps(context.Background())
+		done <- err
+	}()
+
+	waitForFlushAllInFlightForTest(t)
+
+	select {
+	case err := <-done:
+		t.Fatalf("global flush returned before cache use was released: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	if _, err := os.Stat(depDir); err != nil {
+		t.Fatalf("dep dir should remain while cache use is active: %v", err)
+	}
+
+	release()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("global flush after cache use release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("global flush did not finish after cache use was released")
+	}
+
+	if _, err := os.Stat(filepath.Join(diskCachePath, "deps")); !os.IsNotExist(err) {
+		t.Fatalf("deps dir should be deleted after cache use is released")
+	}
+}
+
 func TestResolveDeps_WaitsForTargetedFlush(t *testing.T) {
 	mockS3 := setupTestServerWithMockS3(t)
 	resetDepInstallInFlightForTest(t)
@@ -2989,6 +3105,50 @@ func TestResolveDeps_WaitsForTargetedFlush(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("flush did not finish after in-flight upload completed")
 	}
+}
+
+func TestResolveDeps_WaitsForInFlightBeforeDiskHit(t *testing.T) {
+	setupTestServerWithMockS3(t)
+	resetDepInstallInFlightForTest(t)
+
+	lockContent := []byte("resolve-waits-for-inflight-before-disk-hit")
+	hash := hashBunLock(lockContent)
+	depDir := filepath.Join(diskCachePath, "deps", hash)
+	if err := os.MkdirAll(filepath.Join(depDir, "node_modules", "zod"), 0755); err != nil {
+		t.Fatalf("seed partial dep dir: %v", err)
+	}
+
+	inflight := newDepInstallResult()
+	inflight.path = depDir
+	depInstallMu.Lock()
+	depInstallInFlight[hash] = inflight
+	depInstallMu.Unlock()
+
+	resolveDone := make(chan error, 1)
+	go func() {
+		pkg := &v3PackageJSON{Dependencies: map[string]string{"zod": "3.23.0"}}
+		_, err := resolveDeps(context.Background(), lockContent, pkg, []byte(`{"dependencies":{"zod":"3.23.0"}}`))
+		resolveDone <- err
+	}()
+
+	select {
+	case err := <-resolveDone:
+		t.Fatalf("resolveDeps returned before in-flight deps were ready: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(inflight.ready)
+
+	select {
+	case err := <-resolveDone:
+		if err != nil {
+			t.Fatalf("resolveDeps after in-flight ready: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("resolveDeps did not finish after in-flight deps became ready")
+	}
+
+	close(inflight.done)
 }
 
 func TestCloseDepInstallResult_RemovesEntryBeforeWakingWaiters(t *testing.T) {
@@ -3158,14 +3318,23 @@ func seedDepsTarball(t *testing.T, mockS3 *MockS3Client, key string, name string
 func resetDepInstallInFlightForTest(t *testing.T) {
 	t.Helper()
 	depInstallMu.Lock()
+	previousCacheUseDone := depCacheUseDone
+	previousCacheUseCounts := depCacheUseCounts
+	previousFlushAll := depFlushAllInFlight
 	previousInstalls := depInstallInFlight
 	previousFlushes := depFlushInFlight
+	depCacheUseDone = make(map[string]chan struct{})
+	depCacheUseCounts = make(map[string]int)
+	depFlushAllInFlight = nil
 	depInstallInFlight = make(map[string]*depInstallResult)
 	depFlushInFlight = make(map[string]chan struct{})
 	depInstallMu.Unlock()
 
 	t.Cleanup(func() {
 		depInstallMu.Lock()
+		depCacheUseDone = previousCacheUseDone
+		depCacheUseCounts = previousCacheUseCounts
+		depFlushAllInFlight = previousFlushAll
 		depInstallInFlight = previousInstalls
 		depFlushInFlight = previousFlushes
 		depInstallMu.Unlock()
@@ -3190,6 +3359,29 @@ func waitForFlushInFlightForTest(t *testing.T, hash string) {
 		select {
 		case <-deadline:
 			t.Fatal("flush did not mark hash as in-flight")
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForFlushAllInFlightForTest(t *testing.T) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		depInstallMu.Lock()
+		exists := depFlushAllInFlight != nil
+		depInstallMu.Unlock()
+		if exists {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatal("global flush did not mark deps as in-flight")
 		case <-ticker.C:
 		}
 	}

--- a/server/v3_test.go
+++ b/server/v3_test.go
@@ -2968,6 +2968,56 @@ func TestPrewarmDeps_ResolvesDependencyCache(t *testing.T) {
 	}
 }
 
+func TestPrewarmDeps_FailsWhenTargetedFlushCannotDeleteS3(t *testing.T) {
+	mockS3 := setupTestServerWithMockS3(t)
+
+	lockContent := []byte("prewarm-flush-s3-delete-error-lockfile")
+	hash := hashBunLock(lockContent)
+	key := depsCacheS3Key(hash)
+	seedDepsTarball(t, mockS3, key, "node_modules/zod/index.js", []byte("module.exports = {}"))
+	mockS3.deleteObjectErrors[key] = fmt.Errorf("delete denied")
+
+	staleDiskFile := filepath.Join(diskCachePath, "deps", hash, "node_modules", "zod", "index.js")
+	if err := os.MkdirAll(filepath.Dir(staleDiskFile), 0755); err != nil {
+		t.Fatalf("seed disk cache dir: %v", err)
+	}
+	if err := os.WriteFile(staleDiskFile, []byte("module.exports = { stale: true }"), 0644); err != nil {
+		t.Fatalf("seed disk cache file: %v", err)
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("/bun.lock", string(lockContent)); err != nil {
+		t.Fatalf("write bun.lock field: %v", err)
+	}
+	if err := writer.WriteField("/package.json", `{"dependencies":{"zod":"3.23.0"}}`); err != nil {
+		t.Fatalf("write package.json field: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v3/prewarm-deps?flush=true", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	w := httptest.NewRecorder()
+	prewarmDeps(w, req)
+
+	resp := w.Result()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", resp.StatusCode, string(respBody))
+	}
+	if !strings.Contains(string(respBody), "failed to flush deps") {
+		t.Fatalf("expected flush failure response, got: %s", string(respBody))
+	}
+	if _, exists := mockS3.files[key]; !exists {
+		t.Fatalf("S3 deps tarball should remain when delete fails")
+	}
+	if _, err := os.Stat(staleDiskFile); !os.IsNotExist(err) {
+		t.Fatalf("disk cache should stay empty instead of rehydrating stale S3 deps")
+	}
+}
+
 func seedDepsTarball(t *testing.T, mockS3 *MockS3Client, key string, name string, content []byte) {
 	t.Helper()
 

--- a/server/v3_test.go
+++ b/server/v3_test.go
@@ -2928,6 +2928,69 @@ func TestFlushDepsHash_WaitsForInFlightUpload(t *testing.T) {
 	}
 }
 
+func TestResolveDeps_WaitsForTargetedFlush(t *testing.T) {
+	mockS3 := setupTestServerWithMockS3(t)
+	resetDepInstallInFlightForTest(t)
+
+	lockContent := []byte("resolve-waits-for-targeted-flush")
+	hash := hashBunLock(lockContent)
+	depDir := filepath.Join(diskCachePath, "deps", hash)
+	if err := os.MkdirAll(filepath.Join(depDir, "node_modules", "zod"), 0755); err != nil {
+		t.Fatalf("seed dep dir: %v", err)
+	}
+	key := depsCacheS3Key(hash)
+	mockS3.files[key] = "cached"
+
+	inflight := newDepInstallResult()
+	inflight.path = depDir
+	close(inflight.ready)
+	depInstallMu.Lock()
+	depInstallInFlight[hash] = inflight
+	depInstallMu.Unlock()
+
+	flushDone := make(chan error, 1)
+	go func() {
+		_, err := flushDepsHash(context.Background(), hash)
+		flushDone <- err
+	}()
+
+	waitForFlushInFlightForTest(t, hash)
+
+	resolveCtx, cancelResolve := context.WithCancel(context.Background())
+	resolveDone := make(chan error, 1)
+	go func() {
+		pkg := &v3PackageJSON{Dependencies: map[string]string{"zod": "3.23.0"}}
+		_, err := resolveDeps(resolveCtx, lockContent, pkg, []byte(`{"dependencies":{"zod":"3.23.0"}}`))
+		resolveDone <- err
+	}()
+
+	select {
+	case err := <-resolveDone:
+		t.Fatalf("resolveDeps returned while targeted flush was active: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	cancelResolve()
+	select {
+	case err := <-resolveDone:
+		if err != context.Canceled {
+			t.Fatalf("expected canceled resolve while waiting for flush, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("resolveDeps did not stop waiting after context cancellation")
+	}
+
+	close(inflight.done)
+	select {
+	case err := <-flushDone:
+		if err != nil {
+			t.Fatalf("flush after in-flight upload: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("flush did not finish after in-flight upload completed")
+	}
+}
+
 func TestCloseDepInstallResult_RemovesEntryBeforeWakingWaiters(t *testing.T) {
 	resetDepInstallInFlightForTest(t)
 
@@ -3095,13 +3158,39 @@ func seedDepsTarball(t *testing.T, mockS3 *MockS3Client, key string, name string
 func resetDepInstallInFlightForTest(t *testing.T) {
 	t.Helper()
 	depInstallMu.Lock()
-	previous := depInstallInFlight
+	previousInstalls := depInstallInFlight
+	previousFlushes := depFlushInFlight
 	depInstallInFlight = make(map[string]*depInstallResult)
+	depFlushInFlight = make(map[string]chan struct{})
 	depInstallMu.Unlock()
 
 	t.Cleanup(func() {
 		depInstallMu.Lock()
-		depInstallInFlight = previous
+		depInstallInFlight = previousInstalls
+		depFlushInFlight = previousFlushes
 		depInstallMu.Unlock()
 	})
+}
+
+func waitForFlushInFlightForTest(t *testing.T, hash string) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		depInstallMu.Lock()
+		_, exists := depFlushInFlight[hash]
+		depInstallMu.Unlock()
+		if exists {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatal("flush did not mark hash as in-flight")
+		case <-ticker.C:
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Add targeted dependency cache flushing with `/v3/flush-deps?lock_hash=<sha256>` while preserving the existing global flush behavior when no hash is provided.
- Add `/v3/prewarm-deps` so publish flows can flush and prewarm the current lock hash before requests hit compile/typecheck.
- Keep dependency install temp directories under the cache volume so successful installs can rename into place without crossing filesystems.

## Verification
- `go test . -run 'Test(FlushDeps|PrewarmDeps|ResolveDeps)'`
- `go test .`
- `go test ./...`