### PR TITLE
Deploy FlyTSGo from server repo

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ on:
       - '.github/workflows/docker.yml'
 
 env:
+  FLY_APP: flick-staging-tsgo
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/server
 
@@ -136,3 +137,26 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+  deploy:
+    needs: merge
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly
+        run: |
+          flyctl deploy \
+            --app "$FLY_APP" \
+            --config server/fly.toml \
+            --image "$REGISTRY/$IMAGE_NAME:latest" \
+            --yes

--- a/server/fly.toml
+++ b/server/fly.toml
@@ -1,0 +1,42 @@
+# Fly app configuration for flick-staging-tsgo.
+# The Docker image publish workflow deploys this app after pushing ghcr.io/zshannon/typescript-go/server:latest.
+
+app = 'flick-staging-tsgo'
+primary_region = 'sjc'
+
+[build]
+image = "ghcr.io/zshannon/typescript-go/server:latest"
+
+[env]
+AWS_ENDPOINT_URL_S3 = "https://t3.storage.dev"
+AWS_REGION = "auto"
+DISK_CACHE_PATH = "/data/cache"
+S3_BUCKET = "fly-tsgo-node-modules"
+
+[[mounts]]
+destination = "/data/cache"
+source = "cache_data"
+
+[http_service]
+internal_port = 8080
+force_https = true
+auto_stop_machines = 'suspend'
+auto_start_machines = true
+min_machines_running = 0
+processes = ['app']
+idle_timeout = '10m'
+
+[[http_service.checks]]
+interval = "1s"
+timeout = "1s"
+grace_period = "5s"
+method = "GET"
+path = "/health"
+
+[[vm]]
+size = 'performance-2x'
+memory = 4096
+
+[metrics]
+port = 9091
+path = "/metrics"


### PR DESCRIPTION
## Summary
- Add `server/fly.toml` so the Fly app config lives with the server image source.
- Add a `deploy` job to the Docker image workflow that runs after the multi-arch manifest is published.
- Deploy `ghcr.io/zshannon/typescript-go/server:latest` to `flick-staging-tsgo` using `secrets.FLY_API_TOKEN`.

## TODO
- [ ] Add a `FLY_API_TOKEN` Actions secret to this repository with deploy access for the `flick-staging-tsgo` app.

## Verification
- Remote readback of `.github/workflows/docker.yml` and `server/fly.toml` from `zcs/deploy-flytsgo-from-server-repo`.
- Not run locally; workflow-only deployment wiring and it cannot complete until `FLY_API_TOKEN` exists in this repository.