### PR TITLE
server: support preserve module resolution

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -143,12 +143,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Load Fly deploy token
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          FLY_API_TOKEN: op://tsgo Production/FLY_API_KEY/credential
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.ONEPASSWORD_SERVICE_ACCOUNT }}
 
       - name: Set up flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master

--- a/.github/workflows/exedev-deploy.yml
+++ b/.github/workflows/exedev-deploy.yml
@@ -104,7 +104,7 @@ jobs:
             --env "TSGO_AUTH_PUBLIC_KEY=$TSGO_AUTH_PUBLIC_KEY" \
             --tag tsgo \
             --tag exedev \
-            --comment "TSGo server ${GITHUB_SHA}" \
+            --comment="TSGo-${GITHUB_SHA}" \
             --json
 
           ssh -i ~/.ssh/exedev exe.dev share port "$VM_NAME" 8080

--- a/.github/workflows/exedev-deploy.yml
+++ b/.github/workflows/exedev-deploy.yml
@@ -1,0 +1,111 @@
+name: Deploy TSGo to exe.dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      cpu:
+        default: '2'
+        description: exe.dev vCPU count
+        required: true
+      disk:
+        default: 10GB
+        description: exe.dev disk size
+        required: true
+      image:
+        default: ghcr.io/zshannon/typescript-go/server:latest
+        description: Container image to deploy
+        required: true
+      memory:
+        default: 2GB
+        description: exe.dev memory size
+        required: true
+      region:
+        default: lax
+        description: exe.dev region for new VMs
+        required: true
+      replace_existing:
+        default: false
+        description: Delete and recreate the named VM before deploying
+        required: true
+        type: boolean
+      vm_name:
+        default: tsgo-bench
+        description: exe.dev VM name
+        required: true
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      DISK_CACHE_PATH: /data/cache
+      GHCR_REGISTRY_AUTH: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+      OTEL_SERVICE_NAME: fly-tsgo-exedev
+
+    steps:
+      - name: Load TSGo deploy secrets
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          AWS_ACCESS_KEY_ID: op://chci4awhcucoy66jgoombntpu4/FLY_TSGO_TIGRIS/AWS_ACCESS_KEY_ID
+          AWS_ENDPOINT_URL_S3: op://chci4awhcucoy66jgoombntpu4/FLY_TSGO_TIGRIS/AWS_ENDPOINT_URL_S3
+          AWS_REGION: op://chci4awhcucoy66jgoombntpu4/FLY_TSGO_TIGRIS/AWS_REGION
+          AWS_SECRET_ACCESS_KEY: op://chci4awhcucoy66jgoombntpu4/FLY_TSGO_TIGRIS/AWS_SECRET_ACCESS_KEY
+          EXE_DEV_SSH_PRIVATE_KEY: op://tsgo Production/EXE_DEV/private key
+          HONEYCOMB_API_KEY: op://chci4awhcucoy66jgoombntpu4/FLY_TSGO_HONEYCOMB/credential
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.ONEPASSWORD_SERVICE_ACCOUNT }}
+          S3_BUCKET: op://chci4awhcucoy66jgoombntpu4/FLY_TSGO_TIGRIS/S3_BUCKET
+          TSGO_AUTH_PUBLIC_KEY: op://chci4awhcucoy66jgoombntpu4/flick-staging-tsgo/public-key
+
+      - name: Configure SSH
+        run: |
+          set -euo pipefail
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$EXE_DEV_SSH_PRIVATE_KEY" > ~/.ssh/exedev
+          chmod 600 ~/.ssh/exedev
+          ssh-keyscan exe.dev >> ~/.ssh/known_hosts
+
+      - name: Deploy VM
+        env:
+          EXEDEV_CPU: ${{ inputs.cpu }}
+          EXEDEV_DISK: ${{ inputs.disk }}
+          EXEDEV_IMAGE: ${{ inputs.image }}
+          EXEDEV_MEMORY: ${{ inputs.memory }}
+          EXEDEV_REGION: ${{ inputs.region }}
+          REPLACE_EXISTING: ${{ inputs.replace_existing }}
+          VM_NAME: ${{ inputs.vm_name }}
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/exedev exe.dev set-region "$EXEDEV_REGION"
+
+          if [[ "$REPLACE_EXISTING" == "true" ]]; then
+            ssh -i ~/.ssh/exedev exe.dev rm "$VM_NAME" || true
+          fi
+
+          ssh -i ~/.ssh/exedev exe.dev new \
+            --name "$VM_NAME" \
+            --image "$EXEDEV_IMAGE" \
+            --registry-auth "$GHCR_REGISTRY_AUTH" \
+            --cpu "$EXEDEV_CPU" \
+            --memory "$EXEDEV_MEMORY" \
+            --disk "$EXEDEV_DISK" \
+            --env "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+            --env "AWS_ENDPOINT_URL_S3=$AWS_ENDPOINT_URL_S3" \
+            --env "AWS_REGION=$AWS_REGION" \
+            --env "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+            --env "DISK_CACHE_PATH=$DISK_CACHE_PATH" \
+            --env "HONEYCOMB_API_KEY=$HONEYCOMB_API_KEY" \
+            --env "OTEL_SERVICE_NAME=$OTEL_SERVICE_NAME" \
+            --env "S3_BUCKET=$S3_BUCKET" \
+            --env "TSGO_AUTH_PUBLIC_KEY=$TSGO_AUTH_PUBLIC_KEY" \
+            --tag tsgo \
+            --tag exedev \
+            --comment "TSGo server ${GITHUB_SHA}" \
+            --json
+
+          ssh -i ~/.ssh/exedev exe.dev share port "$VM_NAME" 8080
+          ssh -i ~/.ssh/exedev exe.dev share set-public "$VM_NAME"

--- a/server/README.md
+++ b/server/README.md
@@ -254,7 +254,7 @@ If `/tsconfig.json` is included in the upload, the server parses its `compilerOp
 |-------|--------|
 | `strict` | `true` / `false` |
 | `target` | `"es2020"`, `"es2021"`, `"es2022"`, `"es2023"`, `"es2024"`, `"es2025"`, `"esnext"` |
-| `module` | `"commonjs"`, `"esnext"`, `"nodenext"` |
+| `module` | `"commonjs"`, `"esnext"`, `"nodenext"`, `"preserve"` |
 | `moduleResolution` | `"bundler"`, `"nodenext"`, `"node"` |
 | `jsx` | `"react"`, `"react-jsx"`, `"react-jsxdev"`, `"preserve"` |
 | `jsxImportSource` | any string (e.g., `"@crayonnow/core"`, `"react"`) |
@@ -273,7 +273,7 @@ If absent, the server uses these defaults (matching the v2 hardcoded options):
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["ES2022"],
-    "module": "commonjs",
+    "module": "preserve",
     "moduleResolution": "bundler",
     "noEmit": true,
     "resolveJsonModule": true,

--- a/server/bench_v3_test.go
+++ b/server/bench_v3_test.go
@@ -135,7 +135,7 @@ func buildV3BenchMultipart(files map[string]string, packageJSON string, tsconfig
 
 const benchPackageJSON = `{"main": "/index.tsx", "dependencies": {"@crayonnow/core": "1.0.0", "react": "18.0.0"}, "esbuild": {"bundle": true}}`
 
-var benchTsconfigRaw = []byte(`{"compilerOptions": {"lib": ["ES2022", "DOM"], "jsx": "react-jsx", "jsxImportSource": "@crayonnow/core", "module": "commonjs", "moduleResolution": "bundler", "skipLibCheck": true, "strict": true, "target": "es2022"}}`)
+var benchTsconfigRaw = []byte(`{"compilerOptions": {"lib": ["ES2022", "DOM"], "jsx": "react-jsx", "jsxImportSource": "@crayonnow/core", "module": "preserve", "moduleResolution": "bundler", "skipLibCheck": true, "strict": true, "target": "es2022"}}`)
 
 // Layer 1: Pure Compiler -- calls typecheckV3 directly
 func BenchmarkV3Typecheck(b *testing.B) {

--- a/server/v3_test.go
+++ b/server/v3_test.go
@@ -729,6 +729,111 @@ func TestTypecheckV3_TypeError(t *testing.T) {
 	}
 }
 
+func TestTypecheckV3PreserveBundlerKeepsPackageSelfReferenceIdentity(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "v3-typecheck-preserve-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	oldDiskCachePath := diskCachePath
+	t.Cleanup(func() { diskCachePath = oldDiskCachePath })
+	diskCachePath = tmpDir
+
+	lockContent := []byte("preserve-self-reference-lock")
+	hash := hashBunLock(lockContent)
+	nmDir := filepath.Join(tmpDir, "deps", hash, "node_modules")
+	writeFile := func(path string, content string) {
+		t.Helper()
+		fullPath := filepath.Join(nmDir, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeFile("nominal/package.json", `{
+		"name": "nominal",
+		"version": "1.0.0",
+		"exports": {
+			".": {
+				"import": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+				"require": { "types": "./dist/index.d.cts", "default": "./dist/index.cjs" }
+			}
+		}
+	}`)
+	writeFile("nominal/dist/index.d.ts", `export declare class FluidValue<T> { private readonly importBrand: T }
+export declare class SpringValue<T> extends FluidValue<T> {}`)
+	writeFile("nominal/dist/index.d.cts", `export declare class FluidValue<T> { private readonly requireBrand: T }
+export declare class SpringValue<T> extends FluidValue<T> {}`)
+	writeFile("nominal/dist/index.js", `export {}`)
+	writeFile("nominal/dist/index.cjs", `module.exports = {}`)
+
+	writeFile("pkg/package.json", `{
+		"name": "pkg",
+		"version": "1.0.0",
+		"exports": {
+			".": {
+				"import": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+				"require": { "types": "./dist/index.d.cts", "default": "./dist/index.cjs" }
+			},
+			"./parrott": {
+				"import": { "types": "./dist/parrott/index.d.ts", "default": "./dist/parrott/index.js" },
+				"require": { "types": "./dist/parrott/index.d.cts", "default": "./dist/parrott/index.cjs" }
+			},
+			"./spring": {
+				"import": { "types": "./dist/spring.d.ts", "default": "./dist/spring.js" },
+				"require": { "types": "./dist/spring.d.cts", "default": "./dist/spring.cjs" }
+			}
+		}
+	}`)
+	writeFile("pkg/dist/index.d.ts", `import type { FluidValue } from 'nominal'
+export type Color = string | FluidValue<string>
+export interface TextProps { style?: { color?: Color } }`)
+	writeFile("pkg/dist/index.d.cts", `import type { FluidValue } from 'nominal'
+export type Color = string | FluidValue<string>
+export interface TextProps { style?: { color?: Color } }`)
+	writeFile("pkg/dist/spring.d.ts", `import type { SpringValue } from 'nominal'
+export declare function useSpring(): { color: SpringValue<string> }`)
+	writeFile("pkg/dist/spring.d.cts", `import type { SpringValue } from 'nominal'
+export declare function useSpring(): { color: SpringValue<string> }`)
+	writeFile("pkg/dist/parrott/index.d.ts", `export type { TitleProps } from './card'`)
+	writeFile("pkg/dist/parrott/index.d.cts", `export type { TitleProps } from './card'`)
+	writeFile("pkg/dist/parrott/card.d.ts", `import type * as Core from 'pkg'
+export type TitleProps = Core.TextProps`)
+	writeFile("pkg/dist/index.js", `export {}`)
+	writeFile("pkg/dist/index.cjs", `module.exports = {}`)
+	writeFile("pkg/dist/spring.js", `export function useSpring() { return {} }`)
+	writeFile("pkg/dist/spring.cjs", `exports.useSpring = function() { return {} }`)
+	writeFile("pkg/dist/parrott/index.js", `export {}`)
+	writeFile("pkg/dist/parrott/index.cjs", `module.exports = {}`)
+
+	files := map[string][]byte{
+		"/index.ts": []byte(`import type { TitleProps } from 'pkg/parrott'
+import { useSpring } from 'pkg/spring'
+
+const spring = useSpring()
+const props: TitleProps = { style: { color: spring.color } }
+
+export default props`),
+	}
+	tsconfigRaw := []byte(`{
+		"compilerOptions": {
+			"module": "preserve",
+			"moduleResolution": "bundler",
+			"skipLibCheck": true,
+			"strict": true,
+			"target": "ES2023"
+		}
+	}`)
+
+	response := typecheckV3(files, tsconfigRaw, lockContent)
+	if !response.Pass {
+		t.Fatalf("expected pass, got errors: %+v", response.Errors)
+	}
+}
+
 // Task 9: compileV3 and isExternal tests
 
 func TestCompileV3_SimpleBundle(t *testing.T) {
@@ -1810,6 +1915,7 @@ func TestParseTSConfig(t *testing.T) {
 			{"esnext", core.ModuleKindESNext},
 			{"node16", core.ModuleKindNode16},
 			{"nodenext", core.ModuleKindNodeNext},
+			{"preserve", core.ModuleKindPreserve},
 		}
 		for _, tc := range cases {
 			raw := []byte(fmt.Sprintf(`{"compilerOptions": {"module": "%s"}}`, tc.input))

--- a/server/v3_typecheck.go
+++ b/server/v3_typecheck.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// defaultCompilerOptions returns the default tsconfig options matching v2 hardcoded values.
+// defaultCompilerOptions returns the default tsconfig options for v3 typechecking.
 func defaultCompilerOptions() *core.CompilerOptions {
 	jsxImportSource := "@crayonnow/core"
 	return &core.CompilerOptions{
@@ -29,7 +29,7 @@ func defaultCompilerOptions() *core.CompilerOptions {
 		Jsx:                              core.JsxEmitReactJSX,
 		JsxImportSource:                  jsxImportSource,
 		Lib:                              []string{"ES2022"},
-		Module:                           core.ModuleKindCommonJS,
+		Module:                           core.ModuleKindPreserve,
 		ModuleResolution:                 core.ModuleResolutionKindBundler,
 		NoEmit:                           core.TSTrue,
 		ResolveJsonModule:                core.TSTrue,
@@ -113,6 +113,8 @@ func parseTSConfig(tsconfigRaw []byte) (*core.CompilerOptions, error) {
 		opts.Module = core.ModuleKindNodeNext
 	case "node16":
 		opts.Module = core.ModuleKindNode16
+	case "preserve":
+		opts.Module = core.ModuleKindPreserve
 	}
 
 	// ModuleResolution


### PR DESCRIPTION
## Summary

- Support `module: preserve` in v3 TSGo typechecking and make it the default with bundler resolution.
- Add a regression for package self-reference identity through export conditions.
- Add manual exe.dev deploy workflow and load TSGo deploy credentials from 1Password.
- Load the Fly deploy token from 1Password in the existing Docker deploy workflow.

## Verification

- `go test .` from `server/`
- `git diff --check`
- Verified all workflow `op://...` references with `op read` without printing secret values.
